### PR TITLE
adding error handling for non-existent parse file arg

### DIFF
--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -19,6 +19,7 @@ Parse the SQLite3 database from NVprof or Nsight and print a dictionary for ever
 """
 
 import sys
+import os
 import argparse
 from tqdm import tqdm
 
@@ -33,6 +34,10 @@ def parseArgs():
     parser.add_argument("file", type=str, default=None, help="SQLite3 database.")
 
     args = parser.parse_args()
+
+    if not os.path.isfile(args.file):
+        raise parser.error("No such file '{}'.".format(args.file))
+
     return args
 
 


### PR DESCRIPTION
Hello and thank you for the great tool. I noticed that if you run parse.py on a nonexistent file like

`python -m pyprof.parse non_existent_file.sqlite > net.dict`

there is no error thrown and net.dict contains `no such table: CUPTI_ACTIVITY_KIND_KERNEL`. I added very simple error handling for the case of a non-existent input file.

Signed-off-by: Alex Minnaar <minnaaralex@gmail.com>