### PR TITLE
Fixed torch.any().

### DIFF
--- a/pyprof/prof/misc.py
+++ b/pyprof/prof/misc.py
@@ -214,11 +214,18 @@ class Any(OperatorLayerBase):
 
         assert (mod == "Tensor")
         assert (op == "any")
-        assert (len(args) == 1)  #could be 2 as well, the second argument is a bool
+        assert (len(args) in [1,2])
         t = args[0]
+        # The input can be a tensor or scalar
+        assert (t['type'] in ["tensor", "bool"])
 
-        self.shape = t['shape']
-        self.type = t['dtype']
+        if t['type'] == "tensor":
+          self.shape = t['shape']
+          self.type = t['dtype']
+        else:
+          self.shape = (1,)
+          self.type = t['type']
+          
         self.sub = d.sub
         return
 


### PR DESCRIPTION
The first argument can be a tensor or scalar. Fixes issue https://github.com/NVIDIA/PyProf/issues/36

Signed-off-by: Aditya Agrawal <aditya.iitb@gmail.com>