### PR TITLE
Uniquify funcstack node names

### DIFF
--- a/pyprof/nvtx/config.py
+++ b/pyprof/nvtx/config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Config:
+    __instance = None
+    enable_func_stack = False
+
+    @staticmethod
+    def getInstance():
+        if Config.__instance == None:
+            Config()
+        return Config.__instance
+    
+    def __init__(self):
+        if Config.__instance != None:
+            raise Exception("This is a singleton")
+        else:
+            Config.__instance = self
+    
+    def setConfig(self, **kwargs):
+        print("tkg in set_config")
+        for k,v in kwargs.items():
+            print(k,v)
+        self.enable_func_stack = kwargs.get("enable_function_stack", False)
+
+    def isFuncStackEnabled(self):
+        return self.enable_func_stack

--- a/pyprof/nvtx/config.py
+++ b/pyprof/nvtx/config.py
@@ -30,4 +30,3 @@ class Config:
         else:
             Config.__instance = self
             self.func_stack_enabled = kwargs.get("enable_function_stack", False)
-        

--- a/pyprof/nvtx/config.py
+++ b/pyprof/nvtx/config.py
@@ -17,7 +17,7 @@
 
 class Config:
     __instance = None
-    enable_func_stack = False
+    func_stack_enabled = False
 
     @staticmethod
     def getInstance():
@@ -25,17 +25,10 @@ class Config:
             Config()
         return Config.__instance
     
-    def __init__(self):
+    def __init__(self, **kwargs):
         if Config.__instance != None:
             raise Exception("This is a singleton")
         else:
             Config.__instance = self
-    
-    def setConfig(self, **kwargs):
-        print("tkg in set_config")
-        for k,v in kwargs.items():
-            print(k,v)
-        self.enable_func_stack = kwargs.get("enable_function_stack", False)
-
-    def isFuncStackEnabled(self):
-        return self.enable_func_stack
+            self.func_stack_enabled = kwargs.get("enable_function_stack", False)
+        

--- a/pyprof/nvtx/config.py
+++ b/pyprof/nvtx/config.py
@@ -17,7 +17,6 @@
 
 class Config:
     __instance = None
-    func_stack_enabled = False
 
     @staticmethod
     def getInstance():

--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -108,6 +108,7 @@ def traceMarker(op_name):
     # well as removing any back-to-back duplicates
     # 
     def cleanup_func_stack(func_stack, op_name):
+
         ret = ""
         prev_fn_name = ""
         suffix = ""
@@ -126,6 +127,7 @@ def traceMarker(op_name):
 
             if not should_skip_frame_name(fn_name, prev_fn_name):
                 ret += "/" + fn_name
+                prev_fn_name = fn_name
         ret += "/" + op_name + suffix
         return ret
 

--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -565,6 +565,13 @@ def patch_model_configs():
 
 
 def init(**kwargs):
+    """
+    Initialize pyprof and monkey-patch Torch functions
+
+    Kwargs:
+        enable_function_stack (bool): When true, function stack information will be added to NVTX markers
+    """
+
     config = Config(**kwargs)
 
     print("Initializing NVTX monkey patches")

--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -40,10 +40,8 @@ import inspect as ins
 import traceback
 import math
 import json
+from .config import Config
 
-# Flag to indicate if traceMarker should collect a func_stack or not
-#
-enable_func_stack = False
 
 def isfunc(mod, f):
     assert hasattr(mod, f)
@@ -161,7 +159,7 @@ def traceMarker(op_name):
 
             # Early exit if we aren't doing any funcStack code
             #
-            if (not enable_func_stack):
+            if not Config.getInstance().isFuncStackEnabled():
                 continue
 
             # Build funcStack
@@ -197,7 +195,7 @@ def traceMarker(op_name):
             #
             func_stack = func_stack + "/" + fn_name
 
-        if (enable_func_stack):
+        if Config.getInstance().isFuncStackEnabled():
             func_stack = cleanup_func_stack(func_stack, op_name)
 
         return cadena, func_stack
@@ -205,7 +203,7 @@ def traceMarker(op_name):
     d = {}
     tm, fs = get_trace_info(op_name)
     d['traceMarker'] = tm
-    if (enable_func_stack):
+    if Config.getInstance().isFuncStackEnabled():
         d['funcStack'] = fs
     return str(d)
 
@@ -566,9 +564,9 @@ def patch_model_configs():
     patch_never_call_with_args(torch.autograd.profiler.emit_nvtx, "__init__", "emit_nvtx", {"enabled": {True}})
 
 
-def init(enable_fs=False):
-    global enable_func_stack
-    enable_func_stack = enable_fs
+def init(**kwargs):
+    config = Config.getInstance()
+    config.setConfig(**kwargs)
 
     print("Initializing NVTX monkey patches")
 

--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -159,7 +159,7 @@ def traceMarker(op_name):
 
             # Early exit if we aren't doing any funcStack code
             #
-            if not Config.getInstance().isFuncStackEnabled():
+            if not Config.getInstance().func_stack_enabled:
                 continue
 
             # Build funcStack
@@ -195,7 +195,7 @@ def traceMarker(op_name):
             #
             func_stack = func_stack + "/" + fn_name
 
-        if Config.getInstance().isFuncStackEnabled():
+        if Config.getInstance().func_stack_enabled:
             func_stack = cleanup_func_stack(func_stack, op_name)
 
         return cadena, func_stack
@@ -203,7 +203,7 @@ def traceMarker(op_name):
     d = {}
     tm, fs = get_trace_info(op_name)
     d['traceMarker'] = tm
-    if Config.getInstance().isFuncStackEnabled():
+    if Config.getInstance().func_stack_enabled:
         d['funcStack'] = fs
     return str(d)
 
@@ -565,8 +565,7 @@ def patch_model_configs():
 
 
 def init(**kwargs):
-    config = Config.getInstance()
-    config.setConfig(**kwargs)
+    config = Config(**kwargs)
 
     print("Initializing NVTX monkey patches")
 

--- a/qa/L0_function_stack/test_pyprof_func_stack.py
+++ b/qa/L0_function_stack/test_pyprof_func_stack.py
@@ -21,8 +21,10 @@ import inspect
 import unittest
 
 import pyprof
+from pyprof.nvtx.config import Config
 
-pyprof.nvtx.nvmarker.enable_func_stack = True
+config = Config.getInstance()
+config.setConfig(enable_function_stack=True)
 
 class TestPyProfFuncStack(unittest.TestCase):
 

--- a/qa/L0_function_stack/test_pyprof_func_stack.py
+++ b/qa/L0_function_stack/test_pyprof_func_stack.py
@@ -23,8 +23,7 @@ import unittest
 import pyprof
 from pyprof.nvtx.config import Config
 
-config = Config.getInstance()
-config.setConfig(enable_function_stack=True)
+config = Config(enable_function_stack=True)
 
 class TestPyProfFuncStack(unittest.TestCase):
 

--- a/qa/L0_function_stack/test_pyprof_func_stack.py
+++ b/qa/L0_function_stack/test_pyprof_func_stack.py
@@ -200,7 +200,11 @@ def run_tests(test_name):
     suite = unittest.TestSuite()
     for test_case in test_cases:
         suite.addTest(TestPyProfFuncStack(test_case))
-    unittest.TextTestRunner(verbosity=2).run(suite)
-
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        exit(0)
+    else:
+        exit(1)
+        
 if __name__ == '__main__':
     run_tests("test_basic")

--- a/qa/L0_nvtx/test_pyprof_nvtx.py
+++ b/qa/L0_nvtx/test_pyprof_nvtx.py
@@ -565,7 +565,11 @@ def run_tests(precision):
     suite = unittest.TestSuite()
     for test_case in test_cases:
         suite.addTest(TestPyProfNvtx(test_case, precision))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        exit(0)
+    else:
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/qa/L0_pyprof_data/test_pyprof_data.py
+++ b/qa/L0_pyprof_data/test_pyprof_data.py
@@ -120,7 +120,11 @@ def run_tests(test_name):
     suite = unittest.TestSuite()
     for test_case in test_cases:
         suite.addTest(TestPyProfData(test_case))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        exit(0)
+    else:
+        exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uniquify node names so that a function called multiple times from the same hierarchy can be distinguished

Added an opt-in for the funcStack code, so it is off by default.