### PR TITLE
Fix the function count for leaf nodes

### DIFF
--- a/pyprof/nvtx/nvmarker.py
+++ b/pyprof/nvtx/nvmarker.py
@@ -205,7 +205,9 @@ def traceMarker(op_name):
                     fn_name = ins_frame.f_locals['self'].__class__.__name__ + "::" + fn_name
 
 
-            key = (func_stack, frame.name)
+            key = (func_stack, frame.name,"")
+            if (fn_name in ["wrapper_func", "always_benchmark_wrapper"]):
+                key = (func_stack, frame.name, op_name)
 
             if key not in func_map.keys():
                 func_map[key] = {}


### PR DESCRIPTION
multiple calls to wrapper_func from the same hierarchy were treated the same. However, these were wrappers for different function. This now factor in the op name when doing the counting, so we only get a count of THAT op from the current hierarchy.
