### PR TITLE
Speed up database lookups

### DIFF
--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -91,7 +91,7 @@ class Kernel(object):
         self.op = []
 
     def setKernelInfo(self, info):
-        self.kNameId = info['name']
+        self.kNameId = info['nameId']
         self.corrId = int(info['correlationId'])
         start = int(info['start'])
         end = int(info['end'])
@@ -105,6 +105,7 @@ class Kernel(object):
         self.grid = (info['gridX'], info['gridY'], info['gridZ'])
         self.block = (info['blockX'], info['blockY'], info['blockZ'])
         self.timeOffset = Kernel.profStart
+        self.setKernelName(info['name'])
 
     def setKernelName(self, name):
         cadena = demangle(name)

--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -119,18 +119,9 @@ class Kernel(object):
         self.rDuration = info['rEnd'] - info['rStart']
         self.pid = info['pid']
         self.tid = info['tid']
+        self.objId = info['objId']
         assert(self.rStartTime < self.rEndTime)
         assert(self.rStartTime < self.kStartTime)
-
-        # Determine object ID
-        if 'objId' in info:
-            self.objId = info['objId']
-        else:
-		    # calculate it from the process ID (pid) and thread ID (tid)
-		    # object id = pid (little endian 4 bytes) + tid (little endian 8 bytes)
-            objId = struct.pack('<i', self.pid) + struct.pack('<q', self.tid)
-            objId = binascii.hexlify(objId).decode('ascii').upper()
-            self.objId = objId
 
     def setMarkerInfo(self, info):
         self.layerMarkers, self.traceMarkers, self.reprMarkers, self.pyprofMarkers, self.seqMarkers, self.otherMarkers, self.altMarkers, self.seqId, self.altSeqId, self.layer = info

--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -119,6 +119,8 @@ class Kernel(object):
         self.rDuration = info['rEnd'] - info['rStart']
         self.pid = info['pid']
         self.tid = info['tid']
+        assert(self.rStartTime < self.rEndTime)
+        assert(self.rStartTime < self.kStartTime)
 
         # Determine object ID
         if 'objId' in info:

--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -120,8 +120,8 @@ class Kernel(object):
         self.pid = info['pid']
         self.tid = info['tid']
         self.objId = info['objId']
-        assert(self.rStartTime < self.rEndTime)
-        assert(self.rStartTime < self.kStartTime)
+        assert (self.rStartTime < self.rEndTime)
+        assert (self.rStartTime < self.kStartTime)
 
     def setMarkerInfo(self, info):
         self.layerMarkers, self.traceMarkers, self.reprMarkers, self.pyprofMarkers, self.seqMarkers, self.otherMarkers, self.altMarkers, self.seqId, self.altSeqId, self.layer = info

--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -91,7 +91,7 @@ class Kernel(object):
         self.op = []
 
     def setKernelInfo(self, info):
-        self.kNameId = info['nameId']
+        self.kNameId = info['kNameId']
         self.corrId = int(info['correlationId'])
         start = int(info['start'])
         end = int(info['end'])

--- a/pyprof/parse/nsight.py
+++ b/pyprof/parse/nsight.py
@@ -63,21 +63,6 @@ class Nsight(object):
         self.db.execute('CREATE INDEX end_index ON marker (end)')
         #self.db.execute('CREATE INDEX id_index ON marker (id)')
 
-    def getCPUInfo(self, info):
-        """
-		Given database results, return CPU start, end, pid, tid, and objId
-		"""
-
-        start = info['rStart']
-        end = info['rEnd']
-        # globalId = f(pid, tid). Call it objId (for legacy).
-        objId = info['globalTid']
-        pid = info['pid']
-        tid = info['tid']
-
-        assert (end > start)
-        return [start, end, pid, tid, objId]
-
     def getKernelInfo(self):
         """
 		Get GPU kernel info
@@ -87,7 +72,7 @@ class Nsight(object):
               "strings.value as name, "
               "runtime.start as rStart, "
               "runtime.end as rEnd, "
-              "runtime.globalTid as globalTid, "
+              "runtime.globalTid as objId, "
               "runtime.globalTid / 0x1000000 % 0x1000000 AS pid, "
               "runtime.globalTid % 0x1000000 AS tid, "
               "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"

--- a/pyprof/parse/nsight.py
+++ b/pyprof/parse/nsight.py
@@ -71,21 +71,22 @@ class Nsight(object):
         """
 		Get GPU kernel info
 		"""
-        cmd = ("SELECT "
-              "demangledName as kNameId, "
-              "strings.value as name, "
-              "runtime.start as rStart, "
-              "runtime.end as rEnd, "
-              "runtime.globalTid as objId, "
-              "runtime.globalTid / 0x1000000 % 0x1000000 AS pid, "
-              "runtime.globalTid % 0x1000000 AS tid, "
-              "kernels.globalPid / 0x1000000 % 0x1000000 AS kpid, "
-              "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
-              "gridX,gridY,gridZ,blockX,blockY,blockZ "
-              "FROM {} AS kernels "
-              "JOIN {} AS strings ON (kNameId = strings.Id) "
-              "JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId AND kpid = pid) "
-              ).format(self.kernelT, self.stringT, self.runtimeT)
+        cmd = (
+            "SELECT "
+            "demangledName as kNameId, "
+            "strings.value as name, "
+            "runtime.start as rStart, "
+            "runtime.end as rEnd, "
+            "runtime.globalTid as objId, "
+            "runtime.globalTid / 0x1000000 % 0x1000000 AS pid, "
+            "runtime.globalTid % 0x1000000 AS tid, "
+            "kernels.globalPid / 0x1000000 % 0x1000000 AS kpid, "
+            "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
+            "gridX,gridY,gridZ,blockX,blockY,blockZ "
+            "FROM {} AS kernels "
+            "JOIN {} AS strings ON (kNameId = strings.Id) "
+            "JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId AND kpid = pid) "
+        ).format(self.kernelT, self.stringT, self.runtimeT)
         result = self.db.select(cmd)
         return result
 

--- a/pyprof/parse/nsight.py
+++ b/pyprof/parse/nsight.py
@@ -63,6 +63,10 @@ class Nsight(object):
         self.db.execute('CREATE INDEX end_index ON marker (end)')
         #self.db.execute('CREATE INDEX id_index ON marker (id)')
 
+    def encode_object_id(self, info):
+        # Nothing to do for nsight. objId comes out of database
+        assert 'objId' in info
+
     def getKernelInfo(self):
         """
 		Get GPU kernel info

--- a/pyprof/parse/nsight.py
+++ b/pyprof/parse/nsight.py
@@ -52,15 +52,6 @@ class Nsight(object):
         assert (profStart < sys.maxsize)
         return profStart
 
-    def getString(self, id_):
-        """
-		Get the string associated with an id.
-		"""
-        cmd = "select value from {} where id = {}".format(self.stringT, id_)
-        result = self.db.select(cmd)
-        assert (len(result) == 1)
-        return result[0]['value']
-
     def createMarkerTable(self):
         """
 		Create a temporary table and index it to speed up repeated SQL quesries.
@@ -99,9 +90,13 @@ class Nsight(object):
         """
 		Get GPU kernel info
 		"""
-        cmd = "select demangledName as name,correlationId,start,end,deviceId,streamId,gridX,gridY,gridZ,blockX,blockY,blockZ from {}".format(
-            self.kernelT
-        )
+        cmd = ("SELECT "
+              "demangledName AS nameId, "
+              "strings.value as name, "
+              "correlationId,start,end,deviceId,streamId,"
+              "gridX,gridY,gridZ,blockX,blockY,blockZ"
+              " FROM {} "
+              "JOIN {} as strings ON (nameId = strings.Id)").format(self.kernelT, self.stringT)
         result = self.db.select(cmd)
         return result
 

--- a/pyprof/parse/nsight.py
+++ b/pyprof/parse/nsight.py
@@ -75,11 +75,12 @@ class Nsight(object):
               "runtime.globalTid as objId, "
               "runtime.globalTid / 0x1000000 % 0x1000000 AS pid, "
               "runtime.globalTid % 0x1000000 AS tid, "
+              "kernels.globalPid / 0x1000000 % 0x1000000 AS kpid, "
               "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
               "gridX,gridY,gridZ,blockX,blockY,blockZ "
               "FROM {} AS kernels "
               "JOIN {} AS strings ON (kNameId = strings.Id) "
-              "JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId) "
+              "JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId AND kpid = pid) "
               ).format(self.kernelT, self.stringT, self.runtimeT)
         result = self.db.select(cmd)
         return result

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -34,15 +34,6 @@ class NVVP(object):
         self.db = db
         self.markerId = 0
 
-    def encode_object_id(self, pid, tid):
-        """
-		Given process id (pid) and thread id (tid), return the object id.
-		object id = pid (little endian 4 bytes) + tid (little endian 8 bytes)
-		"""
-        objId = struct.pack('<i', pid) + struct.pack('<q', tid)
-        objId = binascii.hexlify(objId).decode('ascii').upper()
-        return objId
-
     def getProfileStart(self):
         """
 		Get the profile start time
@@ -89,6 +80,14 @@ class NVVP(object):
         self.db.execute('CREATE INDEX start_index ON marker (startTime)')
         self.db.execute('CREATE INDEX end_index ON marker (endTime)')
         self.db.execute('CREATE INDEX id_index ON marker (id)')
+
+    def encode_object_id(self, info):
+        """
+        Encode the object ID from the pid and tid values, and put into dict
+        """
+        objId = struct.pack('<i', info['pid']) + struct.pack('<q', info['tid'])
+        objId = binascii.hexlify(objId).decode('ascii').upper()
+        info['objId'] = objId
 
     def getKernelInfo(self):
         """

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -93,19 +93,21 @@ class NVVP(object):
         """
 		Get GPU kernel info
 		"""
-        cmd = ("SELECT "
-              "name AS kNameId, "
-              "strings.value as name, "
-              "coalesce(runtime.start, driver.start) as rStart, "
-              "coalesce(runtime.end, driver.end) as rEnd, "
-              "coalesce(runtime.processId, driver.processId) as pid, "
-              "coalesce(runtime.threadId, driver.threadId) & 0xFFFFFFFF as tid, "
-              "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
-              "gridX,gridY,gridZ,blockX,blockY,blockZ "
-              "FROM {} AS kernels "
-              "JOIN {} AS strings ON (KNameId = strings._id_) "
-              "LEFT JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId) "
-              "LEFT JOIN {} AS driver ON (kernels.correlationId = driver.correlationId) ").format(self.kernelT, self.stringT, self.runtimeT, self.driverT)
+        cmd = (
+            "SELECT "
+            "name AS kNameId, "
+            "strings.value as name, "
+            "coalesce(runtime.start, driver.start) as rStart, "
+            "coalesce(runtime.end, driver.end) as rEnd, "
+            "coalesce(runtime.processId, driver.processId) as pid, "
+            "coalesce(runtime.threadId, driver.threadId) & 0xFFFFFFFF as tid, "
+            "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
+            "gridX,gridY,gridZ,blockX,blockY,blockZ "
+            "FROM {} AS kernels "
+            "JOIN {} AS strings ON (KNameId = strings._id_) "
+            "LEFT JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId) "
+            "LEFT JOIN {} AS driver ON (kernels.correlationId = driver.correlationId) "
+        ).format(self.kernelT, self.stringT, self.runtimeT, self.driverT)
         result = self.db.select(cmd)
         return result
 

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -97,8 +97,8 @@ class NVVP(object):
         cmd = ("SELECT "
               "name AS kNameId, "
               "strings.value as name, "
-              "runtime.start as rStart, "
-              "runtime.end as rEnd, "
+              "coalesce(runtime.start, driver.start) as rStart, "
+              "coalesce(runtime.end, driver.end) as rEnd, "
               "coalesce(runtime.processId, driver.processId) as pid, "
               "coalesce(runtime.threadId, driver.threadId) & 0xFFFFFFFF as tid, "
               "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
@@ -106,7 +106,7 @@ class NVVP(object):
               "FROM {} AS kernels "
               "JOIN {} AS strings ON (KNameId = strings._id_) "
               "LEFT JOIN {} AS runtime ON (kernels.correlationId = runtime.correlationId) "
-              "LEFT JOIN {} AS driver ON (driver.correlationId = runtime.correlationId) ").format(self.kernelT, self.stringT, self.runtimeT, self.driverT)
+              "LEFT JOIN {} AS driver ON (kernels.correlationId = driver.correlationId) ").format(self.kernelT, self.stringT, self.runtimeT, self.driverT)
         result = self.db.select(cmd)
         return result
 

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -90,19 +90,6 @@ class NVVP(object):
         self.db.execute('CREATE INDEX end_index ON marker (endTime)')
         self.db.execute('CREATE INDEX id_index ON marker (id)')
 
-    def getCPUInfo(self, info):
-        """
-		Given database results, return CPU start, end, pid, tid, and objId
-		"""
-        start = info['rStart']
-        end = info['rEnd']
-        pid = info['pid']
-        tid = info['tid']
-        tid = tid & 0xffffffff  #convert to unsigned
-        objId = self.encode_object_id(pid, tid)
-        assert (end > start)
-        return [start, end, pid, tid, objId]
-
     def getKernelInfo(self):
         """
 		Get GPU kernel info
@@ -113,7 +100,7 @@ class NVVP(object):
               "runtime.start as rStart, "
               "runtime.end as rEnd, "
               "coalesce(runtime.processId, driver.processId) as pid, "
-              "coalesce(runtime.threadId, driver.threadId) as tid, "
+              "coalesce(runtime.threadId, driver.threadId) & 0xFFFFFFFF as tid, "
               "kernels.correlationId,kernels.start,kernels.end,deviceId,streamId,"
               "gridX,gridY,gridZ,blockX,blockY,blockZ "
               "FROM {} AS kernels "

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -121,9 +121,13 @@ class NVVP(object):
         """
 		Get GPU kernel info
 		"""
-        cmd = "select name,correlationId,start,end,deviceId,streamId,gridX,gridY,gridZ,blockX,blockY,blockZ from {}".format(
-            self.kernelT
-        )
+        cmd = ("SELECT "
+              "name AS nameId, "
+              "strings.value as name, "
+              "correlationId,start,end,deviceId,streamId,"
+              "gridX,gridY,gridZ,blockX,blockY,blockZ"
+              " FROM {} "
+              "JOIN {} as strings ON (nameId = strings._id_)").format(self.kernelT, self.stringT)
         result = self.db.select(cmd)
         return result
 

--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -77,6 +77,9 @@ def main():
         info = kInfo[i]
         k = Kernel()
 
+        #Calculate/encode object ID
+        nvvp.encode_object_id(info)
+
         #Set kernel info
         k.setKernelInfo(info)
 

--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -86,7 +86,7 @@ def main():
         #Get and set marker and seqid info
         info = nvvp.getMarkerInfo(k.objId, k.rStartTime, k.rEndTime)
         k.setMarkerInfo(info)
-        
+
         #If the seqId contains both 0 and non zero integers, remove 0.
         if any(seq != 0 for seq in k.seqId) and (0 in k.seqId):
             k.seqId.remove(0)

--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -81,7 +81,7 @@ def main():
         k.setKernelInfo(info)
 
         #Get runtime info
-        info = nvvp.getCPUInfo(k.corrId)
+        info = nvvp.getCPUInfo(info)
         k.setRunTimeInfo(info)
 
         #Get and set marker and seqid info

--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -80,14 +80,10 @@ def main():
         #Set kernel info
         k.setKernelInfo(info)
 
-        #Get runtime info
-        info = nvvp.getCPUInfo(info)
-        k.setRunTimeInfo(info)
-
         #Get and set marker and seqid info
         info = nvvp.getMarkerInfo(k.objId, k.rStartTime, k.rEndTime)
         k.setMarkerInfo(info)
-
+        
         #If the seqId contains both 0 and non zero integers, remove 0.
         if any(seq != 0 for seq in k.seqId) and (0 in k.seqId):
             k.seqId.remove(0)

--- a/pyprof/parse/parse.py
+++ b/pyprof/parse/parse.py
@@ -80,10 +80,6 @@ def main():
         #Set kernel info
         k.setKernelInfo(info)
 
-        #Get, set kernel name
-        name = nvvp.getString(k.kNameId)
-        k.setKernelName(name)
-
         #Get runtime info
         info = nvvp.getCPUInfo(k.corrId)
         k.setRunTimeInfo(info)


### PR DESCRIPTION
I have a small/medium sized database with 63K kernels.  It takes over 10 minutes to run pyprof.parse on it.  My changes drop that to ~25 seconds. I verified output dict is the same for a simple lenet case of nvprof and nsys, and also verified the larger nsys run.