### PR TITLE
avoid frame skips

### DIFF
--- a/pyprof/nvtx/dlprof.py
+++ b/pyprof/nvtx/dlprof.py
@@ -45,8 +45,9 @@ class DLProf(object):
         #    Remove back-to-back duplicates of the same function name.
         #    This is common during recursion
         #
-        if name in ["wrapper_func", "always_benchmark_wrapper"]:
-            return True
+        for prefix in ["wrapper_func", "always_benchmark_wrapper"]:
+            if name.startswith(prefix):
+                return True
         if name == prev_name:
             return True
         return False

--- a/pyprof/nvtx/dlprof.py
+++ b/pyprof/nvtx/dlprof.py
@@ -38,26 +38,14 @@ class DLProf(object):
     # Return True if the name in the hierarchy should be skipped
     @classmethod
     def should_skip_frame_name(cls, name, prev_name):
-        # __call__:
-        #    Much of Torch library is implemented in this way. Ignore these extra layers
         # wrapper_func and always_benchmark_warpper:
         #    Are functions in this file. If there are nested monkeypatched functions
         #    we don't want it to show up
-        # <*>:
-        #    Things like <module>, <genexpr>, <lamba> which don't add any information
-        #    and break html
         # name==prev_name:
         #    Remove back-to-back duplicates of the same function name.
-        #    This is common when python calls the inheritence stack
-        #    For example:
-        #      This: ModelAndLoss::forward/ResNet::forward/Sequential::forward/Bottleneck::forward/BatchNorm2d::forward
-        #      Comes to this function as: forward/forward/forward/forward/forward
-        #      Leaves this function as: forward
+        #    This is common during recursion
         #
-        for prefix in ["__call__", "wrapper_func", "always_benchmark_wrapper"]:
-            if name.startswith(prefix):
-                return True
-        if name.startswith("<") and name.endswith(">"):
+        if name in ["wrapper_func", "always_benchmark_wrapper"]:
             return True
         if name == prev_name:
             return True

--- a/qa/L0_function_stack/test_pyprof_func_stack.py
+++ b/qa/L0_function_stack/test_pyprof_func_stack.py
@@ -114,7 +114,7 @@ class TestPyProfFuncStack(unittest.TestCase):
 
         func1()
 
-    # Test that lambdas are ignored in hierarchy
+    # Test that lambdas are NOT ignored in hierarchy
     # Function stack is func1->func2->lambda->func3->verify
     # Local function 'verify' gets recognized as a member of TestPyProfFuncStack because it uses 'self'
     #
@@ -124,7 +124,7 @@ class TestPyProfFuncStack(unittest.TestCase):
             tracemarker = pyprof.nvtx.nvmarker.traceMarker("opname")
             self.compare_funcstack(
                 tracemarker,
-                "TestPyProfFuncStack::test_ignore_lambda/func1/func2/func3/TestPyProfFuncStack::verify/opname"
+                "TestPyProfFuncStack::test_ignore_lambda/func1/func2/<lambda>/func3/TestPyProfFuncStack::verify/opname"
             )
 
         def func3():


### PR DESCRIPTION
Some parts of the func stack were avoided to try to keep the name clean and short.  This PR adds many of them back in.

Don't merge this until a twin story can be pulled in in DLProf.