### PR TITLE
Signed-off-by: Herbert Hum <hhum@sc-xterm-46.nvidia.com>

### DIFF
--- a/pyprof/prof/blas.py
+++ b/pyprof/prof/blas.py
@@ -132,7 +132,11 @@ class Bmm(OperatorLayerBase):
         assert (k1 == k2)
         t1 = A['dtype']
         t2 = B['dtype']
-        assert (t1 == t2)
+        # assert (t1 == t2).  No longer true.
+        if t1 != t2:
+            if t1 == 'float16' or t2 == 'float16' :
+                A['dtype'] = 'float16'
+                B['dtype'] = 'float16'
 
         self.A = A
         self.B = B

--- a/pyprof/prof/linear.py
+++ b/pyprof/prof/linear.py
@@ -50,7 +50,10 @@ class Linear(OperatorLayerBase):
             x, w, b = args
             assert (x['type'] == w['type'] == "tensor")
             if (b['type'] == "tensor"):
-                assert (len(b['shape']) == 1)
+                # no longer true as b can be of shape [1, XX]
+                # assert (len(b['shape']) == 1)
+                tmp = 1 # dummy statement for commented line above
+                        # TODO: clean up if..elif..else struct
             elif (b['type'] == "NoneType"):
                 assert b['value'] is None
                 b = None
@@ -64,10 +67,13 @@ class Linear(OperatorLayerBase):
         n, k2 = w['shape']
         assert (k1 == k2)
         if b is not None:
-            assert (b['shape'][0] == n)
+            # assert (b['shape'][0] == n)
+            assert(b['shape'][0] == n or 
+                   (b['shape'][0] == 1 and b['shape'][1] == n))
         t1 = x['dtype']
         t2 = w['dtype']
-        assert (t1 == t2)
+        # no longer true
+        # assert (t1 == t2)
 
         # X, W, B
         self.x = x['shape']


### PR DESCRIPTION
Fixed blas.py to support differing source types.
Fixed linear.py to support tensors of shape [1, X] as well as [X].