### PR TITLE
Alexmsettle parse callid

### DIFF
--- a/pyprof/parse/kernel.py
+++ b/pyprof/parse/kernel.py
@@ -171,12 +171,13 @@ class Kernel(object):
             self.op.append(t['op'])
             self.mod.append(t['mod'])
             ## Begin Input node tracking
-            if t['callid'] not in self.callid:
-                self.callid.append(t['callid'])
-            in_callids = t['input_callids']
-            for item in in_callids:
-                if item not in self.input_callids:
-                    self.input_callids.append(item)
+            if 'callid' in t:
+                if t['callid'] not in self.callid:
+                    self.callid.append(t['callid'])
+                in_callids = t['input_callids']
+                for item in in_callids:
+                    if item not in self.input_callids:
+                        self.input_callids.append(item)
             ## End Input node tracking
 
 

--- a/pyprof/parse/nvvp.py
+++ b/pyprof/parse/nvvp.py
@@ -111,6 +111,29 @@ class NVVP(object):
         result = self.db.select(cmd)
         return result
 
+    ## Begin Input node tracking
+    def getAllMarkers(self):
+        '''
+        getAllMarkers()
+        '''
+        callid_markers = {}
+        cmd = "SELECT  id,name from marker ORDER BY startTime ASC"
+        result = self.db.select(cmd)
+        for row in result:
+            marker = self.getString(row['name'])
+            if 'callid' in marker and 'input_callid' in marker:
+                ## Add to a dictionary indexed by callid
+                #print("Found Marker {}".format(marker))
+                item = eval(marker)
+                assert isinstance(item, dict), "Error - marker item {} not a dictionary".format(item)
+                callid = item['callid']
+                if callid not in callid_markers:
+                    callid_markers[callid] = []
+                callid_markers[callid].append(marker)
+
+        return callid_markers
+    ## End Input node tracking
+
     def getMarkerInfo(self, objId, startTime, endTime):
         """
 		This function first finds all NVTX markers encapsulating

--- a/pyprof/prof/activation.py
+++ b/pyprof/prof/activation.py
@@ -42,14 +42,23 @@ class Activation(OperatorLayerBase):
         assert (mod in ["torch.nn.functional", "torch", "Tensor"])
 
         #Filter out named parameters
-        args = list(filter(lambda x: x['name'] == '', args))
 
-        assert (len(args) >= 1)
+        assert (len(args) >= 1), "Activation {} failed - marker {} args {}".format(d, marker, args)
         arg = args[0]
         assert (arg['type'] == "tensor")
 
         self.input = Tensor(arg['shape'], arg['dtype'])
         self.dir = d.dir
+
+    @staticmethod
+    def arg_filter(arg):
+        ret_val = False
+        if arg['name'] == "":
+            ret_val =  True
+
+        raise Exception("Called arg_filter arg {} rev vat {}".format(arg, ret_val))
+        print("Arg filter for {} ret_val {}".format(arg, ret_val))
+        return ret_val
 
     def params(self):
         return str(self.input)

--- a/pyprof/prof/convert.py
+++ b/pyprof/prof/convert.py
@@ -36,7 +36,7 @@ class Convert(OperatorLayerBase):
 
         assert (mod == "Tensor")
         assert (op in Convert.ops)
-        assert (len(args) == 1)
+        assert (len(args) >= 1), "Args {} Len {}".format(args, len(args))
 
         t = args[0]
         if t['type'] == "tensor":

--- a/pyprof/prof/data.py
+++ b/pyprof/prof/data.py
@@ -47,6 +47,9 @@ class Data(object):
         self.seqId = kernel['seqId']
         self.altSeqId = kernel['altSeqId']
 
+        self.callid = kernel['callid']               ## Input Node tracking
+        self.input_callids = kernel['input_callids'] ## Input Node tracking
+
         self.dir = kernel['dir']
         self.sub = kernel['subSeqId']
 

--- a/pyprof/prof/index_slice_join_mutate.py
+++ b/pyprof/prof/index_slice_join_mutate.py
@@ -139,11 +139,7 @@ class Gather(OperatorLayerBase):
         args = list(filter(lambda x: x['name'] != 'out', args))
         assert (len(args) == 3)
 
-        #Get input
-        if (args[0]['name'] == ""):
-            arg = args[0]
-        else:
-            arg = list(filter(lambda x: x['name'] == "input", args))[0]
+        arg = args[0]
 
         assert (arg['type'] == "tensor")
 

--- a/pyprof/prof/misc.py
+++ b/pyprof/prof/misc.py
@@ -129,7 +129,7 @@ class Clone(OperatorLayerBase):
         self.op_ = op
         self.args = args
 
-        assert (mod == "Tensor")
+        assert (mod == "Tensor" or mod == 'torch'), "Mod {} marker {}".format(mod, marker)
         assert (op == "clone")
         assert (len(args) == 1)
         t = args[0]

--- a/pyprof/prof/output.py
+++ b/pyprof/prof/output.py
@@ -29,6 +29,8 @@ class Output():
         "idx": ["Idx", "index", int, 7],
         "seq": ["SeqId", "seqId", str, 7],
         "altseq": ["AltSeqId", "altSeqId", str, 7],
+        "callid":   ["callid",      "callid",   str,    7],    ## Input node tracking
+        "input_callids":    ["input_callids",       "input_callids",    str,    7], ## Input node tracking
         "tid": ["TId", "tid", int, 12],
         "layer": ["Layer", "layer", str, 10],
         "trace": ["Trace", "trace", str, 25],
@@ -37,6 +39,7 @@ class Output():
         "mod": ["Module", "mod", str, 15],
         "op": ["Op", "op", str, 15],
         "kernel": ["Kernel", "name", str, 0],
+        "kernel_lname": ["KernelLName",     "lName",    str,    0],
         "params": ["Params", "params", str, 0],
         "sil": ["Sil(ns)", "sil", int, 10],
         "tc": ["TC", "tc", str, 2],
@@ -56,7 +59,7 @@ class Output():
 
         w = 0
         for col in self.cols:
-            assert col in Output.table.keys()
+            assert col in Output.table.keys(), "col {} not in table".format(col)
             w += Output.table[col][3]
 
         if ((self.col) and (w > self.width)):

--- a/pyprof/prof/pointwise.py
+++ b/pyprof/prof/pointwise.py
@@ -109,7 +109,8 @@ class Pointwise(OperatorLayerBase):
 
         # Filter out all named parameters (kwargs).
         # This might require revisiting in future.
-        args = list(filter(lambda x: x['name'] == "", args))
+        ## Don't want to filter out named parameters, these are needed for
+        ## determining the input tensor shapes
 
         # Filter out non tensors
         #args = list(filter(lambda x: x['type'] == "tensor", args))

--- a/pyprof/prof/prof.py
+++ b/pyprof/prof/prof.py
@@ -220,6 +220,10 @@ def main():
         mod = k['mod']
         op = k['op']
 
+        callid = k['callid']                ## Input node tracking
+        input_callids = k['input_callids']  ## Input node tracking
+
+
         flops = 0
         params = {"na": "na"}
         tc = "na"
@@ -243,6 +247,9 @@ def main():
                     d.modMarker = kernels[index]['reprMarkers']
                     mod = kernels[index]['mod']
                     op = kernels[index]['op']
+
+                    callid = kernels[index]['callid']                ## Input node tracking
+                    input_callids = kernels[index]['input_callids']  ## Input node tracking
 
                     d.layer = kernels[index]['layer']
                     d.trace = kernels[index]['trace']
@@ -279,6 +286,8 @@ def main():
         d.bytes = bytes
         d.mod = mod
         d.op = op
+        d.callid = callid               ## Input node tracking
+        d.input_callids = input_callids ## Input node tracking
 
         output.data(d)
 

--- a/pyprof/prof/reduction.py
+++ b/pyprof/prof/reduction.py
@@ -35,9 +35,6 @@ class Mean(OperatorLayerBase):
         assert (mod in ["torch", "Tensor"])
         assert (op == "mean")
 
-        #Filter out named parameters
-        args = list(filter(lambda x: x['name'] == '', args))
-
         assert (len(args) <= 2)
         i = args[0]
 
@@ -93,11 +90,7 @@ class Sum(OperatorLayerBase):
         assert (op == "sum")
         assert (len(args) >= 1)
 
-        #Get input
-        if (args[0]['name'] == ""):
-            i = args[0]
-        else:
-            i = list(filter(lambda x: x['name'] == "input", args))[0]
+        i = args[0]
 
         self.shape = i['shape']
         self.type = i['dtype']

--- a/pyprof/prof/softmax.py
+++ b/pyprof/prof/softmax.py
@@ -86,16 +86,11 @@ class LogSoftmax(OperatorLayerBase):
         assert (mod in ["torch", "torch.nn.functional"])
         assert (op == "log_softmax")
 
-        #Filter out named parameters
-        args = list(filter(lambda x: x['name'] == '', args))
 
         assert (len(args) <= 2)
 
         #Get input
-        if (args[0]['name'] == ""):
-            i = args[0]
-        else:
-            i = list(filter(lambda x: x['name'] == "input", args))[0]
+        i = args[0]
 
         self.input = Tensor(i['shape'], i['dtype'])
         self.dir = d.dir

--- a/pyprof/prof/usage.py
+++ b/pyprof/prof/usage.py
@@ -26,8 +26,9 @@ def parseArgs():
 
     def check_cols(value):
         valid = [
-            "idx", "seq", "altseq", "tid", "layer", "trace", "dir", "sub", "mod", "op", "kernel", "params", "sil", "tc",
-            "device", "stream", "grid", "block", "flops", "bytes"
+            "idx", "seq", "altseq", "tid", "layer", "trace", "dir", "sub", "mod", "op", "kernel",\
+            "kernel_lname", "params", "sil", "tc",\
+            "device", "stream", "grid", "block", "flops", "bytes", "callid", "input_callids"\
         ]
         cols = value.split(",")
         for col in cols:

--- a/qa/L0_pyprof_data/test_pyprof_data.py
+++ b/qa/L0_pyprof_data/test_pyprof_data.py
@@ -50,6 +50,8 @@ class TestPyProfData(unittest.TestCase):
                         "{'mod': 'Tensor', 'op': 'float', 'args': [{'name': '', 'type': 'tensor', 'shape': (18, 104, 160), 'dtype': 'bool'}]}"
                     ],
                 'seqMarker': ['to, seq = 60471'],
+                'callid': [10],
+                'input_callids': ['3'],
                 'seqId': [60471],
                 'subSeqId':
                     0,
@@ -82,6 +84,8 @@ class TestPyProfData(unittest.TestCase):
                         "{'mod': 'Tensor', 'op': 'clone', 'args': [{'name': '', 'type': 'tensor', 'shape': (18, 4, 416, 640), 'dtype': 'float32'}]}"
                     ],
                 'seqMarker': ['clone, seq = 60161'],
+                'callid': [15],
+                'input_callids': ['4'],
                 'seqId': [60161],
                 'subSeqId':
                     0,


### PR DESCRIPTION
I updated the parse and prof scripts to include the callid and input_callid fields in the final report.  The callid is the unique id of the op, and the input_callids are the inputs of the predecessor ops.  This is sufficient information to build the network graph.  Software can postprocess the pyprof report and produce a graph visualization.

`
Idx | SeqId | AltSeqId | callid | input_callids | TId
-- | -- | -- | -- | -- | --
1 | 4848 | - | [2] | [-1] | 424
2 | 4849 | - | [6] | [-1] | 424
3 | 4849 | - | [15] | ['6', '2'] | 424
4 | 4849 | - | [15] | ['6', '2'] | 424
5 | 4850 | - | [19] | [-1] | 424
6 | 4850 | - | [20] | ['15', -1] | 424
7 | 4851 | - | [22] | ['20'] | 424
8 | 4852 | - | [24] | ['22'] | 424
9 | 4853 | - | [28] | [-1] | 424
10 | 4854 | - | [40] | ['24', '28'] | 424
11 | 4855 | - | [44] | [-1] | 424
12 | 4855 | - | [45] | ['40', -1] | 424

`