### PR TITLE
Fixed assertion in log_softmax.

### DIFF
--- a/pyprof/prof/softmax.py
+++ b/pyprof/prof/softmax.py
@@ -83,7 +83,7 @@ class LogSoftmax(OperatorLayerBase):
         self.mod_ = mod
         self.op_ = op
 
-        assert (mod in ["torch", "torch.nn.functional"])
+        assert (mod in ["torch", "Tensor", "torch.nn.functional"])
         assert (op == "log_softmax")
 
         #Filter out named parameters


### PR DESCRIPTION
While fixing https://github.com/NVIDIA/PyProf/issues/139, this [assertion](https://github.com/NVIDIA/PyProf/blob/master/pyprof/prof/softmax.py#L86) also got triggered. Tensor.log_softmax is a valid operation but is not documented.

Signed-off-by: Aditya Agrawal <aditya.iitb@gmail.com>