### PR TITLE
Fixed error in torch.clamp.

### DIFF
--- a/pyprof/prof/pointwise.py
+++ b/pyprof/prof/pointwise.py
@@ -145,7 +145,8 @@ class Pointwise(OperatorLayerBase):
 
         # Unary
         if self.op() in Pointwise.unary + Pointwise.representation:
-            assert (len(self.input) == 1)
+            # Relaxing assert. clamp has > 1 input arguments.
+            assert (len(self.input) >= 1)
             b = 2 * self.input[0].bytes
             f = self.input[0].size
 


### PR DESCRIPTION
Clamp has > 1 input arguments. However, only the first argument is used.

Signed-off-by: Aditya Agrawal <aditya.iitb@gmail.com>